### PR TITLE
implemented CollaborativeList.length setter

### DIFF
--- a/lib/src/realtime/CollaborativeList.dart
+++ b/lib/src/realtime/CollaborativeList.dart
@@ -36,6 +36,7 @@ class CollaborativeList<E> extends CollaborativeObject /* with ListMixin<E> */ {
   E _fromJs(dynamic value) => _translator == null ? value : _translator.fromJs(value);
 
   /*@override*/ int get length => $unsafe['length'];
+  set length(int l) => $unsafe['length'] = l;
 
   /*@override*/ E operator [](int index) {
     if (index < 0 || index >= this.length) throw new RangeError.value(index);


### PR DESCRIPTION
just directly calls js side length setter. An error when the argument is greater than the current length is just a string and is automatically thrown on the dart side if it occurs.

https://developers.google.com/drive/realtime/reference/gapi.drive.realtime.CollaborativeList#gapi.drive.realtime.CollaborativeList.prototype.length
